### PR TITLE
Add shared cargo and setor types

### DIFF
--- a/frontNext/my-next-app/src/app/Funcionarios/page.tsx
+++ b/frontNext/my-next-app/src/app/Funcionarios/page.tsx
@@ -1,21 +1,12 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Funcionario } from '@/types/funcionario/funcionario'
+import { Funcionario, Cargo, Setor } from '@/types/funcionario/funcionario'
 import TabelaFuncionarios from '@/components/TabelaFuncionario'
 import ModalFuncionario   from '@/components/ModalFuncionario'
 import ModalNovoFuncionario from '@/components/ModalNovoFuncionario'
 import '@/styles/funcionarios.css'
 
-interface Cargo {
-  id: number
-  cargo: string    // 'RC','TC','GE'
-}
-
-interface Setor {
-  id: number
-  setor: string    // 'RE','OF','ES'
-}
 
 export default function FuncionariosPage() {
   const [funcionarios, setFuncionarios] = useState<Funcionario[]>([])

--- a/frontNext/my-next-app/src/components/ModalFuncionario/index.tsx
+++ b/frontNext/my-next-app/src/components/ModalFuncionario/index.tsx
@@ -2,13 +2,11 @@
 'use client'
 
 import React, { useState,ChangeEvent } from 'react'
-import { Funcionario } from '@/types/funcionario/funcionario'
+import { Funcionario, Cargo, Setor } from '@/types/funcionario/funcionario'
 import InputCampo from '@/components/InputCampo'
 import Button from '@/components/buton'
 import '@/styles/components/modalFuncionario.css'
 
-interface Cargo { id: number; cargo: string }
-interface Setor { id: number; setor: string }
 
 interface ModalFuncionarioProps {
   funcionario: Funcionario

--- a/frontNext/my-next-app/src/components/ModalNovoFuncionario/index.tsx
+++ b/frontNext/my-next-app/src/components/ModalNovoFuncionario/index.tsx
@@ -2,19 +2,11 @@
 
 
 import React, { useState,ChangeEvent  } from 'react'
-import { Funcionario, FuncionarioForm } from '@/types/funcionario/funcionario'
+import { Funcionario, FuncionarioForm, Cargo, Setor } from '@/types/funcionario/funcionario'
 import InputCampo from '@/components/InputCampo'
 import Button from '@/components/buton'
 import '@/styles/components/modalFuncionario.css'
 
-interface Cargo {
-  id: number
-  cargo: 'TC' | 'GE' | 'RC'
-}
-interface Setor {
-  id: number
-  setor: 'RE' | 'OF' | 'ES'
-}
 
 interface ModalNovoFuncionarioProps {
   onClose: () => void

--- a/frontNext/my-next-app/src/components/TabelaFuncionario/index.tsx
+++ b/frontNext/my-next-app/src/components/TabelaFuncionario/index.tsx
@@ -1,19 +1,10 @@
 'use client'
 
 import { useState } from 'react'
-import { Funcionario } from '@/types/funcionario/funcionario'
+import { Funcionario, Cargo, Setor } from '@/types/funcionario/funcionario'
 import Button from '@/components/buton' 
 import '@/styles/components/tabelaFuncionario.css'
 
-interface Cargo {
-  id: number
-  cargo: string
-}
-
-interface Setor {
-  id: number
-  setor: string
-}
 
 interface Props {
   funcionarios: Funcionario[]

--- a/frontNext/my-next-app/src/types/funcionario/funcionario.ts
+++ b/frontNext/my-next-app/src/types/funcionario/funcionario.ts
@@ -3,6 +3,16 @@ export interface CargoFuncionario {
   setor: string | null
 }
 
+export interface Cargo {
+  id: number
+  cargo: 'TC' | 'GE' | 'RC'
+}
+
+export interface Setor {
+  id: number
+  setor: 'RE' | 'OF' | 'ES'
+}
+
 export interface Funcionario {
   id: number
   nome: string | null


### PR DESCRIPTION
## Summary
- add `Cargo` and `Setor` interfaces to the funcionario types
- use these shared types in Funcionarios page and related components

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca1802080833096d0c6beaec9e3d1